### PR TITLE
Banner Fix

### DIFF
--- a/Communication/Packets/Incoming/Users/UserBannerSelectEvent.cs
+++ b/Communication/Packets/Incoming/Users/UserBannerSelectEvent.cs
@@ -17,7 +17,7 @@ internal sealed class UserBannerSelectEvent : IPacketEvent
             return;
         }
 
-        if (!BannerManager.TryGetBannerById(bannerId, out var banner))
+        if (!BannerManager.TryGetBannerById(bannerId, out var banner) && bannerId != -1)
         {
             return;
         }


### PR DESCRIPTION

https://github.com/WibboOrg/WibboEmulator/assets/163551540/f26996be-a0ee-4a9c-a0aa-7270d1f2c489

as seen in the video, if we attempt to select empty banner in inventory, it doesn't work because when we select empty banner, the bannerId in the select banner packet is -1 and that can't pass the if condition "BannerManager.TryGetBannerById", so i added another condition which checks if bannerId is -1